### PR TITLE
Fix path of plugin file

### DIFF
--- a/lib/cookpad_departure_defaults.rb
+++ b/lib/cookpad_departure_defaults.rb
@@ -4,7 +4,7 @@ require "departure"
 module CookpadDepartureDefaults
 
   def self.pt_plugin_path
-    File.join(File.expand_path(__FILE__),
+    File.join(File.expand_path(__dir__),
               "cookpad_departure_defaults",
               "pt-online-schema-change-fast-rebuild-constraints.pl")
   end

--- a/lib/cookpad_departure_defaults.rb
+++ b/lib/cookpad_departure_defaults.rb
@@ -4,7 +4,7 @@ require "departure"
 module CookpadDepartureDefaults
 
   def self.pt_plugin_path
-    File.join(File.expand_path(__dir__),
+    File.join(__dir__,
               "cookpad_departure_defaults",
               "pt-online-schema-change-fast-rebuild-constraints.pl")
   end


### PR DESCRIPTION
Getting the following error when running migrations

`ActiveRecord::StatementInvalid: Departure::Error: --plugin file lib/cookpad_departure_defaults.rb/cookpad_departure_defaults/pt-online-schema-change-fast-rebuild-constraints.pl does not exist`
