### PR TITLE
Override tmp directory with environment variable

### DIFF
--- a/lib/cookpad_departure_defaults.rb
+++ b/lib/cookpad_departure_defaults.rb
@@ -21,7 +21,8 @@ module CookpadDepartureDefaults
         --alter-foreign-keys-method\ rebuild_constraints).join(" ")
   end
 
-  Departure.configure {}
-  Departure.configuration.global_percona_args = global_percona_args
-
+  Departure.configure do |config|
+    config.global_percona_args = global_percona_args
+    config.tmp_path = ENV['DEPARTURE_TMP_DIR'] if ENV['DEPARTURE_TMP_DIR']
+  end
 end


### PR DESCRIPTION
This allows us to configure Departure to use different directories in different environments easily.