### PR TITLE
Defer rebuilding self-referencing foreign key until copying rows is done

### DIFF
--- a/lib/cookpad_departure_defaults/pt-online-schema-change-plugin.pl
+++ b/lib/cookpad_departure_defaults/pt-online-schema-change-plugin.pl
@@ -13,10 +13,15 @@ sub init {
   $self->{orig_tbl} = $args{orig_tbl};
 }
 
-sub after_alter_new_table {
+sub after_create_new_table {
+  my ($self, %args) = @_;
+  $self->{new_tbl} = $args{new_tbl};
+}
+
+sub after_copy_rows {
   my ($self, %args) = @_;
   my $orig_tbl = $self->{orig_tbl};
-  my $new_tbl = $args{new_tbl};
+  my $new_tbl = $self->{new_tbl};
   my $tp = TableParser->new;
   my $dbh = $self->{cxn}->dbh;
   my $ddl =  $tp->get_create_table($dbh, $new_tbl->{db}, $new_tbl->{tbl});
@@ -24,13 +29,23 @@ sub after_alter_new_table {
   foreach my $name (keys %$fks) {
     my $fk = $fks->{$name};
     if ($fk->{parent_tblname} eq $orig_tbl->{name}) {
-      # Rebuild a self-referencing foreign key in a new table to make it refer to itself
-      print "Fixing self-referencing foreign key ${name} in table $new_tbl->{name}...\n";
-      my $sql = "ALTER TABLE $new_tbl->{name} DROP FOREIGN KEY `${name}`";
-      $dbh->do($sql);
+      # Rebuild a self-referencing foreign key in a new table to make it refer to itself.
       (my $constraint = $fk->{ddl}) =~ s/REFERENCES[^\(]+/REFERENCES $new_tbl->{name} /;
-      my $sql = "ALTER TABLE $new_tbl->{name} ADD $constraint";
+
+      # Rename the constraint to avoid a conflict.
+      my $new_name;
+      if ($name =~ /^__/) {
+        ($new_name = $name) =~ s/^__//;
+      } else {
+        $new_name = '_' . $name;
+      }
+      $constraint =~ s/CONSTRAINT `$name`/CONSTRAINT `$new_name`/;
+
+      print "Fixing self-referencing foreign key $name in table $new_tbl->{name}...\n";
+      $dbh->do("SET foreign_key_checks = 0");
+      my $sql = "ALTER TABLE $new_tbl->{name} DROP FOREIGN KEY `$name`, ADD $constraint";
       $dbh->do($sql);
+      $dbh->do("SET foreign_key_checks = 1");
     }
   }
 }


### PR DESCRIPTION
While pt-osc is copying rows from an original table to a new table, insert/update/delete requests propagated with triggers may fail with a constraint error because the row referenced from the updated row may not have been copied to the new table yet.

We need to rename a constraint atomically because if the constraint is added by the running migration itself, the original table doesn't have the same constraint and can't prevent violations while the constraint is absent from the new table.